### PR TITLE
Supported injecting compile-time files

### DIFF
--- a/jd4/daemon.py
+++ b/jd4/daemon.py
@@ -87,6 +87,13 @@ class JudgeHandler:
         if not has_lang(self.lang):
             raise SystemError('Unsupported language: {}'.format(self.lang))
         self.config = read_config(config_file, self.lang, self.judge_category)
+        if 'compile_time_files' in self.config:
+            # extract the files to compile directory
+            if self.code_type != CODE_TYPE_TEXT:
+                logger.info("Extracting compile time to code dir '%s'", self.code)
+                self.config['compile_time_files'](self.code)
+            else:
+                logger.warn('Text submission does not support compile time files.')
 
     async def do_submission(self):
         # loop = get_event_loop()

--- a/jd4/util.py
+++ b/jd4/util.py
@@ -2,7 +2,7 @@ import re
 from asyncio import get_event_loop, StreamReader, StreamReaderProtocol
 from os import fdopen, listdir, open as os_open, path, remove, waitpid, rename, rmdir, \
     O_RDONLY, O_NONBLOCK, WEXITSTATUS, WIFSIGNALED, WNOHANG, WTERMSIG
-from shutil import rmtree
+from shutil import rmtree, copytree, copy2, move
 import tarfile
 
 from jd4.error import FormatError
@@ -86,4 +86,13 @@ def extract_tar_file(tmp_dir, sandbox_dir):
     with tarfile.open(file_path) as t:
         t.extractall(path=sandbox_dir)
     remove(file_path)
-    rmdir(tmp_dir)
+    # rmdir(tmp_dir)
+
+
+def movetree(src, dst):
+    # requires both src and dest to exist
+    for item in listdir(src):
+        s = path.join(src, item)
+        d = path.join(dst, item)
+        move(s, d)
+    rmdir(src)


### PR DESCRIPTION
To enable this feature:
- Add an entry to `config.yaml`
- `compile_time_files: subfolder/`
- Put the files to be injected into the compiling process in `subfolder` in the archive.
You should expect them to appear at `subfolder/` folder in the compile location 
Compile them using:
```
g++ -o out /in/main.cpp /in/subfolder/1.cpp /in/subfolder/2.cpp
```

One more comment. If you need to include files in code, you should use `-I` to specify `subfolder` as  an inclusion path. 