### PR TITLE
Add llvm tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ RUN apt-get install -y googletest && \
 # Install clang tools
 RUN apt-get install -y clang-tools clang-format clang-tidy
 
+# Install llvm tools
+RUN apt-get install -y llvm
+
 # Install ocaml
 RUN apt-get install -y ocaml
 


### PR DESCRIPTION
`llvm-symbolizer` is useful when debugging.

## Background

Many courses will check memory problems by using `asan`, `lsan` and `ubsan`. However, on JOJ it cannot show the precise line number because it cannot find `llvm-symbolizer`.

Installing `llvm` package can solve the problem.